### PR TITLE
Added pywin32 and pinned maximum versions in setup.py

### DIFF
--- a/microscope_automation/tests/test_setup_microscope.py
+++ b/microscope_automation/tests/test_setup_microscope.py
@@ -49,3 +49,10 @@ def test_setup_microscope(prefs_path, expected_components):
         list(microscope_object.microscope_components_ordered_dict.keys())
         == expected_components
     )
+
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+def test_import_pywin32():
+    # if pywin32 isn't installed this will throw ImportError and never assert True
+    import win32com.client  # noqa
+    assert True

--- a/microscope_automation/tests/test_setup_microscope.py
+++ b/microscope_automation/tests/test_setup_microscope.py
@@ -57,5 +57,5 @@ def test_import_pywin32():
     # if pywin32 isn't installed this will throw ImportError and never assert True
     if platform == "win32" or platform == "cygwin":
         import win32com.client  # noqa
-        
+
     assert True

--- a/microscope_automation/tests/test_setup_microscope.py
+++ b/microscope_automation/tests/test_setup_microscope.py
@@ -6,6 +6,7 @@ Created on May 20, 2020
 """
 
 import pytest
+from sys import platform
 import microscope_automation.preferences as preferences
 from microscope_automation.hardware.setup_microscope import setup_microscope
 import os
@@ -54,5 +55,7 @@ def test_setup_microscope(prefs_path, expected_components):
 @pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
 def test_import_pywin32():
     # if pywin32 isn't installed this will throw ImportError and never assert True
-    import win32com.client  # noqa
+    if platform == "win32" or platform == "cygwin":
+        import win32com.client  # noqa
+        
     assert True

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
     "lxml>=4.5.2,<4.7",
     "pathlib>=1.0.1,<1.1",
     "pyserial>=3.4,<3.5",
-    "pywin32>=227",
+    "pywin32",
     "scikit-image>=0.16.2,<0.19",
     "scipy>=1.6.0,<1.7",
 ]

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
     "lxml>=4.5.2,<4.7",
     "pathlib>=1.0.1,<1.1",
     "pyserial>=3.4,<3.5",
-    "pywin32",
+    'pywin32>=227,<301 ; platform_system=="Windows"',
     "scikit-image>=0.16.2,<0.19",
     "scipy>=1.6.0,<1.7",
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,27 +30,29 @@ dev_requirements = [
     "coverage>=5.1",
     "ipython>=7.15.0",
     "pytest-runner>=5.2",
-    "Sphinx>=3",
-    "sphinx_rtd_theme>=0.4.3",
+    "Sphinx>=3,<3.5",
+    "sphinx_rtd_theme>=0.4.3,<0.6",
     "tox>=3.15.2",
     "twine>=3.1.1",
     "wheel>=0.34.2",
 ]
 
 requirements = [
-    'tifffile>=2020.8.25',
-    'aicsimageio>=3.2.3',
-    'pandas>=1.1.1',
-    'numpy>=1.19.1',
-    'pyyaml>=5.3.1',
-    'pyqtgraph>=0.11.0',
-    'PyQt5>=5.12.3',
-    'matplotlib>=3.3.1',
-    'formlayout>=1.2.0',
-    'lxml>=4.5.2',
-    'pathlib>=1.0.1',
-    'pyserial>=3.4',
-    'scikit-image>=0.16.2'
+    "tifffile>=2020.8.25,<2021",
+    "aicsimageio>=3.2.3,<3.4",
+    "pandas>=1.1.1,<1.3",
+    "numpy>=1.19.1,<1.20",
+    "pyyaml>=5.3.1,<5.4",
+    "pyqtgraph>=0.11.0,<0.12",
+    "PyQt5>=5.12.3,<5.16",
+    "matplotlib>=3.3.1,<3.4",
+    "formlayout>=1.2.0,<1.3",
+    "lxml>=4.5.2,<4.7",
+    "pathlib>=1.0.1,<1.1",
+    "pyserial>=3.4,<3.5",
+    "pywin32>=227,<301"
+    "scikit-image>=0.16.2,<0.19"
+    "scipy>=1.6.0,<1.7"
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements = [
     "pytest-raises>=0.11",
     "pytest-runner>=5.2",
     "pytest-html>=2.1.1",
-    "mock>=4.0.2"
+    "mock>=4.0.2",
 ]
 
 dev_requirements = [
@@ -50,9 +50,9 @@ requirements = [
     "lxml>=4.5.2,<4.7",
     "pathlib>=1.0.1,<1.1",
     "pyserial>=3.4,<3.5",
-    "pywin32>=227,<301"
-    "scikit-image>=0.16.2,<0.19"
-    "scipy>=1.6.0,<1.7"
+    "pywin32>=227,<301",
+    "scikit-image>=0.16.2,<0.19",
+    "scipy>=1.6.0,<1.7",
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
     "lxml>=4.5.2,<4.7",
     "pathlib>=1.0.1,<1.1",
     "pyserial>=3.4,<3.5",
-    "pywin32>=227,<301",
+    "pywin32>=227",
     "scikit-image>=0.16.2,<0.19",
     "scipy>=1.6.0,<1.7",
 ]


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
  - Resolves #18, Resolves #22 
- [x] Provide context of changes.
  - Since this is just changing package versions, there is no need to update documentation. The tests which failed when pandas auto-upgraded would check similar auto-upgrades, but now we will do manual package upgrades by updating the maximum package versions in `setup.py` at regular intervals and check the tests before merging. Also, when running on the microscope, `pywin32` was required to load a dll but was missing from `setup.py`, so that's been added.
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.
